### PR TITLE
Добавлена кнопка с ссылкой на карту РТУ МИРЭА в меню с расписанием

### DIFF
--- a/src/bot/show_schedule/callbacks/back_to_week_choice_list_callback.py
+++ b/src/bot/show_schedule/callbacks/back_to_week_choice_list_callback.py
@@ -5,7 +5,8 @@ from src.bot.common.safe_message_edit import safe_message_edit
 from src.bot.show_schedule.resources.templates import CHOOSE_SCHEDULE_PERIOD_TEMPLATE
 from src.bot.show_schedule.resources.inline_buttons import show_choose_period_buttons
 from src.bot.show_schedule.callback_data import BackToWeekChoiceListCallbackData
-from src.modules.student_management.domain import Role
+from src.modules.student_management.domain import Role, Student
+from src.modules.edu_info.application.queries import FetchUniAliasByGroupIdQuery
 
 __all__ = [
     "include_back_to_week_choice_list_callback_router",
@@ -23,12 +24,17 @@ def include_back_to_week_choice_list_callback_router(root_router: RootRouter) ->
 
 
 @back_to_week_choice_list_callback_router.callback_query(BackToWeekChoiceListCallbackData.filter())
-async def back_to_week_choice_list(callback: CallbackQuery) -> None:
+async def back_to_week_choice_list(
+        callback: CallbackQuery,
+        student: Student,
+        fetch_uni_alias_by_group_id_query: FetchUniAliasByGroupIdQuery
+) -> None:
     if callback.message is None:
         return
 
+    uni_alias = await fetch_uni_alias_by_group_id_query.execute(student.group_id)
     await safe_message_edit(
         callback,
         CHOOSE_SCHEDULE_PERIOD_TEMPLATE,
-        show_choose_period_buttons()
+        show_choose_period_buttons(uni_alias)
     )

--- a/src/bot/show_schedule/command.py
+++ b/src/bot/show_schedule/command.py
@@ -3,7 +3,8 @@ from aiogram.types import Message
 from src.bot.common import CommandFilter, RootRouter, Router, TelegramCommand
 from src.bot.show_schedule.resources.templates import CHOOSE_SCHEDULE_PERIOD_TEMPLATE
 from src.bot.show_schedule.resources.inline_buttons import show_choose_period_buttons
-from src.modules.student_management.domain import Role
+from src.modules.student_management.domain import Role, Student
+from src.modules.edu_info.application.queries import FetchUniAliasByGroupIdQuery
 
 __all__ = [
     "include_show_schedule_command_router",
@@ -21,8 +22,13 @@ def include_show_schedule_command_router(root_router: RootRouter) -> None:
 
 
 @show_schedule_command_router.message(CommandFilter(TelegramCommand.SHOW_SCHEDULE))
-async def get_attendance_command(message: Message) -> None:
+async def get_attendance_command(
+        message: Message,
+        student: Student,
+        fetch_uni_alias_by_group_id_query: FetchUniAliasByGroupIdQuery
+) -> None:
+    uni_alias = await fetch_uni_alias_by_group_id_query.execute(student.group_id)
     await message.answer(
         CHOOSE_SCHEDULE_PERIOD_TEMPLATE,
-        reply_markup=show_choose_period_buttons()
+        reply_markup=show_choose_period_buttons(uni_alias)
     )

--- a/src/bot/show_schedule/resources/inline_buttons.py
+++ b/src/bot/show_schedule/resources/inline_buttons.py
@@ -8,6 +8,7 @@ from src.bot.show_schedule.callback_data import (
     BackToWeekChoiceListCallbackData,
     ScheduleCertainDayCallbackData
 )
+from src.modules.common.domain import UniversityAlias
 
 __all__ = [
     "show_choose_period_buttons",
@@ -36,7 +37,7 @@ def get_short_name_of_day(weekday: int) -> str:
             pass
 
 
-def show_choose_period_buttons() -> InlineKeyboardMarkup:
+def show_choose_period_buttons(uni: UniversityAlias) -> InlineKeyboardMarkup:
     builder = InlineKeyboardBuilder()
 
     builder.button(text="Сегодня", callback_data=ScheduleDateCallbackData(
@@ -47,6 +48,7 @@ def show_choose_period_buttons() -> InlineKeyboardMarkup:
     builder.button(text="Следующая неделя", callback_data=ScheduleWeekCallbackData(weeks_to_add=1))
     builder.button(text="Неделя после следующей", callback_data=ScheduleWeekCallbackData(weeks_to_add=2))
     builder.button(text="Ввести дату вручную", callback_data=ScheduleCertainDayCallbackData())
+    builder.button(text="Карта РТУ МИРЭА", url="https://map.mirea.ru/") if uni == UniversityAlias.MIREA else ...
 
     builder.adjust(1)
     return builder.as_markup(resize_keyboard=True)


### PR DESCRIPTION
## Основные изменения:


-> В меню с расписанием для студентов РТУ МИРЭА была добавлена новая кнопка, ведущая на сайт с интерактивной картой университета. Подразумевается, что это будет полезно при поиске нужной аудитории во время просмотра расписания.
![image](https://github.com/user-attachments/assets/89e3331f-0490-47b3-bcc9-85ebb380f025)
